### PR TITLE
Remove Google-provided iOS build links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 This is WebRTC framework in XCFramework format for iOS and macOS.
 
-Google provides the official builds for iOS, if all you need is iOS build, get it from Google:
-
-- https://cocoapods.org/pods/GoogleWebRTC
-- https://webrtc.github.io/webrtc-org/native-code/ios/
-
 ## Installation
 
 ### Manual 


### PR DESCRIPTION
Google no longer provides builds.

This change [was announced in January 2020](https://groups.google.com/g/discuss-webrtc/c/Ozvbd0p7Q1Y/m/M4WN2cRKCwAJ), and the last CocoaPods release was in August 2020.